### PR TITLE
Add some tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ for usage instructions.
 | Name                                     | Description                                                          |
 |------------------------------------------|----------------------------------------------------------------------|
 | launch_configuration_name                | The name of the launch configuration for bastion instances           |
-| bastion_security_group_id                | The ID of the security group that allows ssh access to the bastion   |
+| allow_ssh_to_bastion_security_group_id   | The ID of the security group that allows ssh access to the bastion   |
 | allow_ssh_from_bastion_security_group_id | The ID of the security group that allows ssh access from the bastion |
+| bastion_security_group_id                | (deprecated)                                                         |
 | open_to_bastion_security_group_id        | (deprecated)                                                         |
 
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ The bastion requires:
 The bastion consists of:
 * An autoscaling group and launch configuration for bastion instances 
   configured with the supplied SSH key updating the supplied load balancers.
-* A security group allowing access to the bastion from the load balancers.
-* A security group open to the bastion for use on protected instances.
+* A security group allowing SSH access to the bastion from the load balancers.
+* A security group allowing SSH access from the bastion, for assigning to protected instances.
 
 ![Diagram of infrastructure managed by this module](https://raw.githubusercontent.com/infrablocks/terraform-aws-bastion/master/docs/architecture.png)
 
@@ -78,8 +78,8 @@ for usage instructions.
 | ami                   | The ID of the AMI for the bastion instances                       | -       | yes      |
 | instance_type         | The instance type of the bastion instances                        | t2.nano | yes      |
 | ssh_public_key_path   | The absolute path of the SSH public key to use for bastion access | -       | yes      |
-| allowed_cidrs         | The CIDRs that are allowed to access the bastion                  | -       | yes      |
-| egress_cidrs          | The CIDRs that are reachable from the bastion                     | -       | yes      |
+| allowed_cidrs         | The CIDRs that are allowed to access the bastion (list)           | -       | yes      |
+| egress_cidrs          | The CIDRs that are reachable from the bastion (list)              | -       | yes      |
 | load_balancer_names   | The names of the load balancers to update on autoscaling events   | -       | yes      |
 | minimum_instances     | The minimum number of bastion instances                           | -       | yes      |
 | maximum_instances     | The maximum number of bastion instances                           | -       | yes      |
@@ -88,11 +88,12 @@ for usage instructions.
 
 ### Outputs
 
-| Name                              | Description                                                   |
-|-----------------------------------|---------------------------------------------------------------|
-| launch_configuration_name         | The name of the launch configuration for bastion instances    |
-| bastion_security_group_id         | The ID of the bastion's security group                        |
-| open_to_bastion_security_group_id | The ID of the security group allowing access from the bastion |
+| Name                                     | Description                                                          |
+|------------------------------------------|----------------------------------------------------------------------|
+| launch_configuration_name                | The name of the launch configuration for bastion instances           |
+| bastion_security_group_id                | The ID of the security group that allows ssh access to the bastion   |
+| allow_ssh_from_bastion_security_group_id | The ID of the security group that allows ssh access from the bastion |
+| open_to_bastion_security_group_id        | (deprecated)                                                         |
 
 
 Development

--- a/main.tf
+++ b/main.tf
@@ -80,24 +80,7 @@ resource "aws_security_group" "allow_ssh_to_bastion" {
     Name = "allow-ssh-to-bastion-${var.component}-${var.deployment_identifier}"
     Component = "${var.component}"
     DeploymentIdentifier = "${var.deployment_identifier}"
-  }
-
-  tag {
-    key = "Component"
-    value = "${var.component}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "DeploymentIdentifier"
-    value = "${var.deployment_identifier}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Role"
-    value = "bastion"
-    propagate_at_launch = true
+    Role = "bastion"
   }
 
   ingress {
@@ -127,24 +110,7 @@ resource "aws_security_group" "allow_ssh_from_bastion" {
     Name = "allow-ssh-from-bastion-${var.component}-${var.deployment_identifier}"
     Component = "${var.component}"
     DeploymentIdentifier = "${var.deployment_identifier}"
-  }
-
-  tag {
-    key = "Component"
-    value = "${var.component}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "DeploymentIdentifier"
-    value = "${var.deployment_identifier}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key = "Role"
-    value = "bastion"
-    propagate_at_launch = true
+    Role = "bastion"
   }
 
   ingress {

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "aws_launch_configuration" "bastion" {
   key_name = "${aws_key_pair.bastion.key_name}"
 
   security_groups = [
-    "${aws_security_group.bastion.id}"
+    "${aws_security_group.allow_ssh_to_bastion.id}"
   ]
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ data "aws_ami" "amazon_linux" {
 }
 
 resource "aws_key_pair" "bastion" {
-  key_name = "${var.component}-${var.deployment_identifier}"
+  key_name = "bastion-${var.component}-${var.deployment_identifier}"
   public_key = "${file(var.ssh_public_key_path)}"
 }
 
@@ -49,11 +49,11 @@ resource "aws_autoscaling_group" "bastion" {
 
   tag {
     key = "Name"
-    value = "${var.component}-${var.deployment_identifier}"
+    value = "bastion-${var.component}-${var.deployment_identifier}"
     propagate_at_launch = true
   }
 
-  tag{
+  tag {
     key = "Component"
     value = "${var.component}"
     propagate_at_launch = true
@@ -65,21 +65,39 @@ resource "aws_autoscaling_group" "bastion" {
     propagate_at_launch = true
   }
 
-  tag{
+  tag {
     key = "Role"
     value = "bastion"
     propagate_at_launch = true
   }
 }
 
-resource "aws_security_group" "bastion" {
-  name = "${var.component}-${var.deployment_identifier}"
+resource "aws_security_group" "allow_ssh_to_bastion" {
+  name = "allow-ssh-to-bastion-${var.component}-${var.deployment_identifier}"
   vpc_id = "${var.vpc_id}"
 
   tags {
-    Name = "${var.component}-${var.deployment_identifier}"
+    Name = "allow-ssh-to-bastion-${var.component}-${var.deployment_identifier}"
     Component = "${var.component}"
     DeploymentIdentifier = "${var.deployment_identifier}"
+  }
+
+  tag {
+    key = "Component"
+    value = "${var.component}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key = "DeploymentIdentifier"
+    value = "${var.deployment_identifier}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key = "Role"
+    value = "bastion"
+    propagate_at_launch = true
   }
 
   ingress {
@@ -101,14 +119,32 @@ resource "aws_security_group" "bastion" {
   }
 }
 
-resource "aws_security_group" "open_to_bastion" {
-  name = "open-to-bastion-${var.component}-${var.deployment_identifier}"
+resource "aws_security_group" "allow_ssh_from_bastion" {
+  name = "allow-ssh-from-bastion-${var.component}-${var.deployment_identifier}"
   vpc_id = "${var.vpc_id}"
 
   tags {
-    Name = "open-to-bastion-${var.component}-${var.deployment_identifier}"
+    Name = "allow-ssh-from-bastion-${var.component}-${var.deployment_identifier}"
     Component = "${var.component}"
     DeploymentIdentifier = "${var.deployment_identifier}"
+  }
+
+  tag {
+    key = "Component"
+    value = "${var.component}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key = "DeploymentIdentifier"
+    value = "${var.deployment_identifier}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key = "Role"
+    value = "bastion"
+    propagate_at_launch = true
   }
 
   ingress {
@@ -116,7 +152,7 @@ resource "aws_security_group" "open_to_bastion" {
     to_port = 22
     protocol = "tcp"
     security_groups = [
-      "${aws_security_group.bastion.id}"
+      "${aws_security_group.allow_ssh_to_bastion.id}"
     ]
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,7 +8,13 @@ output "bastion_security_group_id" {
   value = "${aws_security_group.bastion.id}"
 }
 
+# For backwards compatibility.
 output "open_to_bastion_security_group_id" {
   description = "The ID of the security group allowing access from the bastion."
-  value = "${aws_security_group.open_to_bastion.id}"
+  value = "${aws_security_group.allow_ssh_from_bastion.id}"
+}
+
+output "allow_ssh_from_bastion_security_group_id" {
+  description = "The ID of the security group allowing ssh access from the bastion."
+  value = "${aws_security_group.allow_ssh_from_bastion.id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "launch_configuration_name" {
 
 output "bastion_security_group_id" {
   description = "The ID of the bastion's security group."
-  value = "${aws_security_group.bastion.id}"
+  value = "${aws_security_group.allow_ssh_to_bastion.id}"
 }
 
 # For backwards compatibility.

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,17 +4,17 @@ output "launch_configuration_name" {
 }
 
 output "bastion_security_group_id" {
-  description = "The ID of the bastion's security group."
+  description = "The ID of the security group that allows ssh access to the bastion."
   value = "${aws_security_group.allow_ssh_to_bastion.id}"
 }
 
-# For backwards compatibility.
-output "open_to_bastion_security_group_id" {
-  description = "The ID of the security group allowing access from the bastion."
+output "allow_ssh_from_bastion_security_group_id" {
+  description = "The ID of the security group that allows ssh access from the bastion."
   value = "${aws_security_group.allow_ssh_from_bastion.id}"
 }
 
-output "allow_ssh_from_bastion_security_group_id" {
-  description = "The ID of the security group allowing ssh access from the bastion."
+# Deprecated: For backwards compatibility.
+output "open_to_bastion_security_group_id" {
+  description = "The ID of the security group that allows ssh access from the bastion."
   value = "${aws_security_group.allow_ssh_from_bastion.id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "launch_configuration_name" {
   value = "${aws_launch_configuration.bastion.name}"
 }
 
-output "bastion_security_group_id" {
+output "allow_ssh_to_bastion_security_group_id" {
   description = "The ID of the security group that allows ssh access to the bastion."
   value = "${aws_security_group.allow_ssh_to_bastion.id}"
 }
@@ -18,3 +18,10 @@ output "open_to_bastion_security_group_id" {
   description = "The ID of the security group that allows ssh access from the bastion."
   value = "${aws_security_group.allow_ssh_from_bastion.id}"
 }
+
+# Deprecated: For backwards compatibility.
+output "bastion_security_group_id" {
+  description = "The ID of the security group that allows ssh access to the bastion."
+  value = "${aws_security_group.allow_ssh_to_bastion.id}"
+}
+


### PR DESCRIPTION
I made some tweaks to names and tags in the course of understanding how to use this.

- I added Role=bastion tags to all the things, to make it clear which resources came from this. This may not reflect the intended convention for the "Role" tag.
- I added "bastion" to the name of the keypair, to clearly distinguish it from other keypairs
- I changed the name of the "bastion" security group to "allow_ssh_to_bastion", and changed "open_to_bastion_security_group_id" to "allow_ssh_from_bastion_security_group_id". This reads more clearly to me, expressing what the group actually does. But this is potentially a matter of taste.

I added new outputs to correlated to the new security group names, but left the previous ones in place for backwards compatibility.
